### PR TITLE
add isvp_t23n_sfcnor_mmc1bit target, support 1-bit only mode

### DIFF
--- a/boards.cfg
+++ b/boards.cfg
@@ -52,6 +52,7 @@ isvp_t21_sfcnor             mips   xburst   isvp_t21    ingenic   t21   isvp_t21
 isvp_t23n_sfcnor            mips   xburst   isvp_t23    ingenic   t23   isvp_t23:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,T23N
 isvp_t23n_sfcnor_hp         mips   xburst   isvp_t23    ingenic   t23   isvp_t23:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,T23N,HP
 isvp_t23n_sfcnor_lp         mips   xburst   isvp_t23    ingenic   t23   isvp_t23:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,T23N,LP
+isvp_t23n_sfcnor_mmc1bit    mips   xburst   isvp_t23    ingenic   t23   isvp_t23:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,T23N,JZ_MMC_1BIT
 
 isvp_t30_sfcnor             mips   xburst   isvp_t30    ingenic   t30   isvp_t30:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0
 isvp_t30_sfcnor_ddr128M     mips   xburst   isvp_t30    ingenic   t30   isvp_t30:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,DDR2_128M

--- a/drivers/mmc/jz_mmc.c
+++ b/drivers/mmc/jz_mmc.c
@@ -356,7 +356,11 @@ static void jz_mmc_init_one(int idx, int controller, uintptr_t base, int clock)
 #ifdef CONFIG_JZ_MMC_MSC0_PA_8BIT
 	mmc->host_caps = MMC_MODE_8BIT | MMC_MODE_HS_52MHz | MMC_MODE_HS | MMC_MODE_HC;
 #else
+#ifdef CONFIG_JZ_MMC_1BIT
+	mmc->host_caps = MMC_MODE_HS_52MHz | MMC_MODE_HS | MMC_MODE_HC;
+#else
 	mmc->host_caps = MMC_MODE_4BIT | MMC_MODE_HS_52MHz | MMC_MODE_HS | MMC_MODE_HC;
+#endif
 #endif
 #else /* CONFIG_FPGA */
 	mmc->host_caps = MMC_MODE_HS_52MHz | MMC_MODE_HS | MMC_MODE_HC;


### PR DESCRIPTION
This target enables CONFIG_JZ_MMC_1BIT which restricts the MMC host controller's capability to 1-bit (instead of 4-bit) mode. Needed for Galayou G2/T23N.